### PR TITLE
Fix comment, grammar and typo issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and show how to implement all the primitives -- each in just a few lines of Go.
 
 # Usage in your projects
 
-Feel free to grab and use this -- just copy the code so you can modify it to suit your ends, and keep the copyright around somewhere.
+Feel free to grab and use this -- just copy the code, so you can modify it to suit your ends, and keep the copyright around somewhere.
 
 The parser API is very loosely inspired by the [parser package](https://package.elm-lang.org/packages/elm/parser/latest/Parser) for the [Elm language](http://elm-lang.org). 
 
@@ -22,7 +22,7 @@ If you want to get more familiar with this implementation of parser combinators,
 
 ## Simpler
 
-* Add a `Parser[Empty]` named `End` which succeeds only when you have no more input remaining.  Remove the check for remaining input in the `Parse` function and modify the example grammar to use `End` to ensure no input remains.
+* Add a `Parser[Empty]` named `End` which succeeds only when you have no more input remaining. Remove the check for remaining input in the `Parse` function and modify the example grammar to use `End` to ensure no input remains.
 
 * Add a function to the `parser` package called `Lookahead` that takes a `Parser[T]` as an argument, and returns a `Parser[T]` which returns the same value as the input parser, but without consuming any input -- in other words, it looks to see if the argument parser matches the upcoming input but doesn't actually consume that input.
 
@@ -30,7 +30,7 @@ If you want to get more familiar with this implementation of parser combinators,
 
 ## More complex
 
-* As written, `OneOf` always backtracks.  Add a function `Commit` that transforms its argument parser such that if it has an error, `OneOf` will immediately fail instead of continuing to try more parsers.  Here's a a rough example, where the idea is that after seeing a `{` if this parser fails, a OneOf containing it should not proceed to try others.
+* As written, `OneOf` always backtracks. Add a function `Commit` that transforms its argument parser such that if it has an error, `OneOf` will immediately fail instead of continuing to try more parsers.  Here's a rough example, where the idea is that after seeing a `{` if this parser fails, a OneOf containing it should not proceed to try others.
 
   ```
   myCodeParser := AndThen(
@@ -46,22 +46,22 @@ If you want to get more familiar with this implementation of parser combinators,
             }
   ```
 
-  Hint: You'll have to modify `OneOf` to make this work.  The interactions between backtracking control and sequencing (with `AndThen` or with the special sequencing forms) also bears thinking about.
+Hint: You'll have to modify `OneOf` to make this work.  The interactions between backtracking control and sequencing (with `AndThen` or with the special sequencing forms) also bears thinking about.
 
 ## Improving the debugging experience:
 
 Because our combinators are implemented as functions, if we use the debugger to analyze mid-parse, we just see a stack of closures.  
 
-* Approach A:  Add a payload data type to `Parser`, so it's `Parser[T any, D any]`.   Write a `WithData` wrapper function that takes a parser and payload data and returns a parser in which incoming `state` will contain the new payload data when the underlying parser is run.  Add a `GetData` parser that, when run, returns the current payload data.   This will enable you to provide contextual data (e.g. in printfs or errors from your parsing.)
+* Approach A: Add a payload data type to `Parser`, so it's `Parser[T any, D any]`.   Write a `WithData` wrapper function that takes a parser and payload data and returns a parser in which incoming `state` will contain the new payload data when the underlying parser is run.  Add a `GetData` parser that, when run, returns the current payload data.   This will enable you to provide contextual data (e.g. in printfs or errors from your parsing.)
 
-* Approach B:  replace the functions with interfaces.   Change the type of `Parser` from `func (state)...` to 
+* Approach B: Replace the functions with interfaces. Change the type of `Parser` from `func (state)...` to 
   ```
      type Parser[T any] interface { 
         parse(state) (T, state, error)
     }
   ```
   
-  Now modify all of the parser-generating and combining functions to return various structs implementing the interface.  The debugger should show a stack of method calls on specific struct types now.  Is it more clear?  (Let me know, I haven't yet tried this myself.)
+Now modify all the parser-generating and combining functions to return various structs implementing the interface.  The debugger should show a stack of method calls on specific struct types now.  Is it more clear?  (Let me know, I haven't yet tried this myself.)
 
 # Feedback appreciated
 

--- a/example/grammar.go
+++ b/example/grammar.go
@@ -1,15 +1,15 @@
-// This package provides a Parser that parses a simple configuration file format
-// made up as an example.  Here is a grammar for the configuration format:
+// Package example provides a Parser that parses a simple configuration file format
+// made up as an example. Here is a grammar for the configuration format:
 //
 //	configuration:  '[' whitespace bindings whitespace ']'
 //
 //	bindings: binding | binding whitespace ',' whitespace bindings
 //
-//	binding:  name whitespace '=' whitespace value
+//	binding: name whitespace '=' whitespace value
 //
 //	name: [a-zA-Z][0-9a-zA-Z]*
 //
-//	value:  int | bool
+//	value: int | bool
 //
 //	int: [0-9] | [1-9][0-9]+
 //
@@ -24,7 +24,7 @@ import (
 	. "github.com/jhbrown-veradept/gophercon22-parser-combnators/parser"
 )
 
-// The result of parsing is a slice of Bindings
+// Bindings is the result of parsing is a slice of Bindings.
 type Bindings []Binding
 
 // A Binding corresponds to “name = value”
@@ -41,17 +41,17 @@ type BindingValue interface {
 // BindingInt is a wrapper on int to implement the BindingValue interface.
 type BindingInt int
 
-// The marker method to be a BindingValue
+// IsBindingValue is the marker method to be a BindingValue.
 func (BindingInt) IsBindingValue() {}
 
 // BindingBool is a wrapper on bool to implement the BindingValue interface.
 type BindingBool bool
 
-// The marker method to be a BindingValue
+// IsBindingValue is the marker method to be a BindingValue.
 func (BindingBool) IsBindingValue() {}
 
-// NewConfigParser returns this struct.  The sole exported field is the Parser for the
-// entire configuration format.  The unexported fields contain subcomponent parsers
+// ConfigParsers holds all parsers. The sole exported field is the Parser for the
+// entire configuration format. The unexported fields contain subcomponent parsers
 // for mutual reference and (ideally) internal testing.
 type ConfigParsers struct {
 	trueParser          Parser[bool]

--- a/parser/loop.go
+++ b/parser/loop.go
@@ -3,17 +3,17 @@ package parser
 // Step is used to tell Loop when to continue looping vs. when to finish parsing.
 type Step[A any, T any] struct {
 	Done  bool // True when Loop should stop looping, False when it should continue
-	Accum A    // Parser state accumulated during iteration.  Should be valid when Done is false.
-	Value T    // Final value to be returned by Loop.  Should be valid when Done is true.
+	Accum A    // Parser state accumulated during iteration. Should be valid when Done is false.
+	Value T    // Final value to be returned by Loop. Should be valid when Done is true.
 }
 
-// Loop returns a parser which can loop over input to produce a T.  Unlike recursive AndThen calls, Loop
+// Loop returns a parser which can loop over input to produce a T. Unlike recursive AndThen calls, Loop
 // produces a stack-safe parser.
 //
-// Loop accumulates data in an A.  startAccum provides the initial (empty) value for A.
-// Each iteration, Loop uses the stepper function applied too the current accumulation value
-// to produce a single-step Parser[Step[A,T]].  On a successful parse, if the Step's Done flag
-// is not set, Loop will iterate with the new Accum value from the Step.  If the Step's Done flag
+// Loop accumulates data in an A. startAccum provides the initial (empty) value for A.
+// Each iteration, Loop uses the stepper function applied to the current accumulation value
+// to produce a single-step Parser[Step[A,T]]. On a successful parse, if the Step's Done flag
+// is not set, Loop will iterate with the new Accum value from the Step. If the Step's Done flag
 // is set, Loop will complete by returning the T value from the Step.
 func Loop[A any, T any](startAccum A, stepper func(A) Parser[Step[A, T]]) Parser[T] {
 	return func(initial state) (T, state, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,7 +3,7 @@
 // All types and functions in this package are safe for concurrent use.
 //
 // The package design is very loosely inspired by the parser package for
-// the Elm language.  See https://package.elm-lang.org/packages/elm/parser/latest/Parser
+// the Elm language. See https://package.elm-lang.org/packages/elm/parser/latest/Parser
 package parser
 
 import (
@@ -11,11 +11,11 @@ import (
 	"strings"
 )
 
-// A Parser[T] is a parser that, on parsing success, produces a value of type T.
+// Parser is a parser that, on parsing success, produces a value of type T.
 //
 // Parser[T] is implemented as a function, but that's a detail that need not
 // concern package users, as Parsers are created by calls to creation, combination, and transformation
-// functions in this package.  Actually parsing an input string is done using the Parse[T] function.
+// functions in this package. Actually parsing an input string is done using the Parse[T] function.
 type Parser[T any] func(state) (T, state, error)
 
 // Empty is the type returned by Parsers that don't return anything more meaningful.
@@ -28,9 +28,9 @@ var (
 	ErrUnconsumedInput = errors.New("unconsumed input") // When parsing succeeded but didn't consume all the input.
 )
 
-// Parse[T] takes a Parser[T] and an input string, and runs the Parser on the input string.
-// On success, Parser returns a value of type T.   Parse[T] returns ErrNoMatch for a failed parse,
-// and ErrUnconsumedInput if the parser succeeded but didn't consume all of the input string.
+// Parse takes a Parser[T] and an input string, and runs the Parser on the input string.
+// On success, Parser returns a value of type T.  Parse[T] returns ErrNoMatch for a failed parse,
+// and ErrUnconsumedInput if the parser succeeded but didn't consume all the input string.
 func Parse[T any](parser Parser[T], data string) (T, error) {
 	initial := state{data: data, offset: 0}
 	result, final, err := parser(initial)
@@ -45,13 +45,13 @@ func Parse[T any](parser Parser[T], data string) (T, error) {
 	return result, err
 }
 
-// Fail[T] is a parser which always fails to match.
+// Fail is a parser which always fails to match.
 func Fail[T any](initial state) (T, state, error) {
 	var zero T
 	return zero, initial, ErrNoMatch
 }
 
-// Succeed[T] returns a Parser[T] which always succeeds by producing the value argment from the call to Succeed.
+// Succeed returns a Parser[T] which always succeeds by producing the value argument from the call to Succeed.
 // Succeed consumes no input.
 func Succeed[T any](value T) Parser[T] {
 	return func(initial state) (T, state, error) {
@@ -59,7 +59,7 @@ func Succeed[T any](value T) Parser[T] {
 	}
 }
 
-// Map[T, A] returns a Parser[A] which transforms the output of a successful parse using
+// Map returns a Parser[A] which transforms the output of a successful parse using
 // the argument parser from type T to type A using the mapper argument.
 func Map[T any, A any](parser Parser[T], mapper func(T) A) Parser[A] {
 	return func(initial state) (A, state, error) {
@@ -72,7 +72,7 @@ func Map[T any, A any](parser Parser[T], mapper func(T) A) Parser[A] {
 	}
 }
 
-// AndThen[T, U] returns a Parser[U] which first parses using the parser argument,
+// AndThen returns a Parser[U] which first parses using the parser argument,
 // and then on success, produces another Parser by calling the handler argument on the
 // result; finally it returns the value of calling the second Parser.
 func AndThen[T any, U any](parser Parser[T], handler func(T) Parser[U]) Parser[U] {
@@ -87,8 +87,8 @@ func AndThen[T any, U any](parser Parser[T], handler func(T) Parser[U]) Parser[U
 	}
 }
 
-// OneOf[T] returns a Parser[T] which will try each Parser in parsers in turn.
-// The value of the first Parser to succeed is returned.  If no Parser succeeds,
+// OneOf returns a Parser[T] which will try each Parser in parsers in turn.
+// The value of the first Parser to succeed is returned. If no Parser succeeds,
 // the last Parser's error is returned, or ErrNoMatch if there were no Parsers at all.
 func OneOf[T any](parsers ...Parser[T]) Parser[T] {
 	return func(initial state) (T, state, error) {
@@ -107,8 +107,8 @@ func OneOf[T any](parsers ...Parser[T]) Parser[T] {
 }
 
 // ConsumeIf returns a Parser which tests the next rune in the input with
-// the condition function.  If the condition is met, the rune is consumed from
-// the input and the parser succeeds.  Otherwise the parser fails.
+// the condition function. If the condition is met, the rune is consumed from
+// the input and the parser succeeds. Otherwise, the parser fails.
 func ConsumeIf(condition func(rune) bool) Parser[Empty] {
 	return func(initial state) (Empty, state, error) {
 		r, next := initial.nextRune()
@@ -120,8 +120,8 @@ func ConsumeIf(condition func(rune) bool) Parser[Empty] {
 }
 
 // ConsumeWhile returns a Parser which tests each successive in the input with
-// the condition function.  For each rune for which the condition is met, the rune is consumed from
-// the input.  The parser finishes when some rune does not meet the condition.
+// the condition function. For each rune for which the condition is met, the rune is consumed from
+// the input. The parser finishes when some rune does not meet the condition.
 // The parser always succeeds, even if no runes are met.
 func ConsumeWhile(condition func(r rune) bool) Parser[Empty] {
 	return func(initial state) (Empty, state, error) {
@@ -137,8 +137,8 @@ func ConsumeWhile(condition func(r rune) bool) Parser[Empty] {
 }
 
 // ConsumeSome returns a Parser which tests each successive in the input with
-// the condition function.  For each rune for which the condition is met, the rune is consumed from
-// the input.  The parser finishes when some rune does not meet the condition.
+// the condition function. For each rune for which the condition is met, the rune is consumed from
+// the input. The parser finishes when some rune does not meet the condition.
 // The parser succeeds if and only if at least one rune is consumed.
 func ConsumeSome(condition func(rune) bool) Parser[Empty] {
 	s := StartSkipping(ConsumeIf(condition))
@@ -146,7 +146,7 @@ func ConsumeSome(condition func(rune) bool) Parser[Empty] {
 }
 
 // Exactly returns a Parser which compares the beginning of the remaining
-// input to the token argument.  If they match, the corresponding amount of input
+// input to the token argument. If they match, the corresponding amount of input
 // is consumed and the parser succeeds, otherwise the parser fails.
 func Exactly(token string) Parser[Empty] {
 	return func(initial state) (Empty, state, error) {
@@ -158,7 +158,7 @@ func Exactly(token string) Parser[Empty] {
 	}
 }
 
-// GetString[T] generates a Parser[string] which succeeds exactly when the parser argument
+// GetString generates a Parser[string] which succeeds exactly when the parser argument
 // succeeds; on success it returns the slice of the input string matched by parser.
 func GetString[T any](parser Parser[T]) Parser[string] {
 	return func(initial state) (string, state, error) {

--- a/parser/sequence.go
+++ b/parser/sequence.go
@@ -1,15 +1,15 @@
 package parser
 
-// Seq[T,U] is used to represent the kept values in parser sequences built using StartKeeping
-// and AppendKeeping.  They are principally passed as arguments to Apply, Apply2, and so on.
+// Seq is used to represent the kept values in parser sequences built using StartKeeping
+// and AppendKeeping. They are principally passed as arguments to Apply, Apply2, and so on.
 // Users usually won't need to write out signatures involving Seq explicitly.
 type Seq[T any, U any] struct {
 	first  T
 	second U
 }
 
-// StartKeeping[T] returns a sequence Parser which, on success, produces a single-element sequence that
-// contains result of the argument parser.  A single-element sequence is modeled as Seq[Empty, T], but this
+// StartKeeping returns a sequence Parser which, on success, produces a single-element sequence that
+// contains result of the argument parser. A single-element sequence is modeled as Seq[Empty, T], but this
 // is a detail that users should be able to ignore most of the time.
 func StartKeeping[T any](parser Parser[T]) Parser[Seq[Empty, T]] {
 	return Map(parser, func(t T) Seq[Empty, T] {
@@ -17,20 +17,20 @@ func StartKeeping[T any](parser Parser[T]) Parser[Seq[Empty, T]] {
 	})
 }
 
-// StartSkipping[T] returns a sequence Parser which, on success, produces a zero-element sequence
-// by discarding the result of running the argument parser.  A zero-element sequence is modeled as Empty
+// StartSkipping returns a sequence Parser which, on success, produces a zero-element sequence
+// by discarding the result of running the argument parser. A zero-element sequence is modeled as Empty
 // but this is a detail that users should be able to ignore most of the time.
 func StartSkipping[T any](parser Parser[T]) Parser[Empty] {
 	return Map(parser, func(T) Empty { return Empty{} })
 }
 
-// AppendKeeping[T, U] returns a sequence Parser which runs its two argument parsers in series, and on success,
-// returns a sequence one element longer than the sequence provided by the parserT argument.  An N-element
-// sequence is modeled as Seq[Seq[Seq[...Seq[Empty, T1]..., TN-2], TN-1], TN]  but, very fortunately,
+// AppendKeeping returns a sequence Parser which runs its two argument parsers in series, and on success,
+// returns a sequence one element longer than the sequence provided by the parserT argument. An N-element
+// sequence is modeled as Seq[Seq[Seq[...Seq[Empty, T1]..., TN-2], TN-1], TN] but, very fortunately,
 // this is a detail that users should be able to ignore most of the time.
 //
 // A user could pass a parserT argument which doesn't produce a sequence, but the result would
-// not work with ApplyN functions so it's hard to imagine the use case.
+// not work with ApplyN functions, so it's hard to imagine the use case.
 func AppendKeeping[T any, U any](parserT Parser[T], parserU Parser[U]) Parser[Seq[T, U]] {
 	return func(initial state) (Seq[T, U], state, error) {
 		t, next, err := parserT(initial)
@@ -47,7 +47,7 @@ func AppendKeeping[T any, U any](parserT Parser[T], parserU Parser[U]) Parser[Se
 	}
 }
 
-// AppendSkipping[T, U] returns a sequence Parser which runs its two argument parsers in series, and on success,
+// AppendSkipping returns a sequence Parser which runs its two argument parsers in series, and on success,
 // returns only the result (presumably a sequence) provided by the parserT argument.
 //
 // A user could pass a parserT argument which doesn't produce a sequence, but the result would
@@ -69,7 +69,7 @@ func AppendSkipping[T any, U any](parserT Parser[T], parserU Parser[U]) Parser[T
 }
 
 // Apply returns a parser by transforming the output of the argument parser, which produces
-// a single-element sequence.  The resulting parser transforms the single value from the sequence
+// a single-element sequence. The resulting parser transforms the single value from the sequence
 // using the argument mapper function.
 func Apply[T any, A any](parser Parser[Seq[Empty, T]], mapper func(T) A) Parser[A] {
 	return func(initial state) (A, state, error) {
@@ -83,7 +83,7 @@ func Apply[T any, A any](parser Parser[Seq[Empty, T]], mapper func(T) A) Parser[
 }
 
 // Apply2 returns a parser by transforming the output of the argument parser, which produces
-// a two-element sequence.  The resulting parser transforms the two values from the sequence
+// a two-element sequence. The resulting parser transforms the two values from the sequence
 // into the final result value using the argument mapper function.
 func Apply2[T any, U any, A any](parser Parser[Seq[Seq[Empty, T], U]], mapper func(T, U) A) Parser[A] {
 	return func(initial state) (A, state, error) {
@@ -97,7 +97,7 @@ func Apply2[T any, U any, A any](parser Parser[Seq[Seq[Empty, T], U]], mapper fu
 }
 
 // Apply3 returns a parser by transforming the output of the argument parser, which produces
-// a three-element sequence.  The resulting parser transforms the three values from the sequence
+// a three-element sequence. The resulting parser transforms the three values from the sequence
 // into the final result value using the argument mapper function.
 func Apply3[T any, U any, V any, A any](parser Parser[Seq[Seq[Seq[Empty, T], U], V]], mapper func(T, U, V) A) Parser[A] {
 	return func(initial state) (A, state, error) {

--- a/parser/state.go
+++ b/parser/state.go
@@ -10,7 +10,7 @@ type state struct {
 	offset int    // The current parsing offset into the input string.
 }
 
-// remaining returns the a string which is just the unconsumed input
+// remaining returns the string which is just the unconsumed input.
 func (s state) remaining() string {
 	return s.data[s.offset:]
 }


### PR DESCRIPTION
This PR fixes the following:
- Comments should start with the function name without type.
- Package comment should start the package name.
- Grammar mistakes (`all the`, missing comma before `so` etc.).
- Typos.
- Unnecessary whitespaces.